### PR TITLE
update cerebellum scaffold usecases

### DIFF
--- a/src/assets/config_files/usecases.json
+++ b/src/assets/config_files/usecases.json
@@ -791,7 +791,7 @@
                 "appid": 175,
                 "contenttype": "x-ipynb+json",
                 "extension": ".ipynb",
-				"file": "b0509c3f-3330-435d-87d2-d0940e98766c"
+                "file": "b0509c3f-3330-435d-87d2-d0940e98766c"
               }
             ],
             "species": "Rat",
@@ -801,8 +801,8 @@
             "contributors": [
               {"name": "Egidio d’Angelo", "email": "egidiougo.dangelo@unipv.it"},
               {"name": "Stefano Casali", "email": "stefano.casali@unipv.it"},
-			  {"name": "Claudia Casellato", "email": "claudia.casellato@unipv.it"},
-			  {"name": "Elisa Marenzi", "email": "elisa.marenzi@unipv.it"}
+              {"name": "Claudia Casellato", "email": "claudia.casellato@unipv.it"},
+              {"name": "Elisa Marenzi", "email": "elisa.marenzi@unipv.it"}
             ],
             "img": "https://github.com/antonelepfl/usecases/raw/dev/src/assets/images/cerebellum.png"
           },
@@ -848,7 +848,7 @@
                 "appid": 175,
                 "contenttype": "x-ipynb+json",
                 "extension": ".ipynb",
-				"file": "85354cea-5f47-4852-8c8f-8cacf5d38333"
+                "file": "85354cea-5f47-4852-8c8f-8cacf5d38333"
               }
             ],
             "species": "Rat",
@@ -858,8 +858,8 @@
             "contributors": [
               {"name": "Egidio d’Angelo", "email": "egidiougo.dangelo@unipv.it"},
               {"name": "Stefano Casali", "email": "stefano.casali@unipv.it"},
-			  {"name": "Claudia Casellato", "email": "claudia.casellato@unipv.it"},
-			  {"name": "Elisa Marenzi", "email": "elisa.marenzi@unipv.it"}
+              {"name": "Claudia Casellato", "email": "claudia.casellato@unipv.it"},
+              {"name": "Elisa Marenzi", "email": "elisa.marenzi@unipv.it"}
             ],
             "img": "https://github.com/antonelepfl/usecases/raw/dev/src/assets/images/cerebellum.png"
           },
@@ -977,15 +977,15 @@
         },
         "next": "small_circuits",
         "models": [
-		  {
+          {
             "title": "Cerebellum microcircuit",
-			"files": [
+            "files": [
               {
                 "entryname": "Cerebellum microcircuit",
                 "appid": 175,
                 "contenttype": "x-ipynb+json",
                 "extension": ".ipynb",
-				"file": "da012b41-4a6b-4b5d-9b71-869c1c68d731"
+                "file": "da012b41-4a6b-4b5d-9b71-869c1c68d731"
               }
             ],
             "species": "Rat",
@@ -995,8 +995,8 @@
             "contributors": [
               {"name": "Egidio d’Angelo", "email": "egidiougo.dangelo@unipv.it"},
               {"name": "Stefano Casali", "email": "stefano.casali@unipv.it"},
-			  {"name": "Claudia Casellato", "email": "claudia.casellato@unipv.it"},
-			  {"name": "Elisa Marenzi", "email": "elisa.marenzi@unipv.it"}
+              {"name": "Claudia Casellato", "email": "claudia.casellato@unipv.it"},
+              {"name": "Elisa Marenzi", "email": "elisa.marenzi@unipv.it"}
             ],
             "img": "https://github.com/antonelepfl/usecases/raw/dev/src/assets/images/cerebellum.png"
           },
@@ -1011,8 +1011,6 @@
             ],
             "img": "https://github.com/antonelepfl/usecases/raw/dev/src/assets/images/hippocampusConnections.png"
           }
-        ]
-          
         ]
       },
       {

--- a/src/assets/config_files/usecases.json
+++ b/src/assets/config_files/usecases.json
@@ -791,7 +791,8 @@
                 "appid": 175,
                 "contenttype": "x-ipynb+json",
                 "extension": ".ipynb",
-                "file": "67555a8f-70f6-4b81-9f2b-c343deb0779c"
+                #"file": "67555a8f-70f6-4b81-9f2b-c343deb0779c"
+				"file": "b0509c3f-3330-435d-87d2-d0940e98766c"
               }
             ],
             "species": "Rat",
@@ -800,7 +801,9 @@
             "description": "A volume of the cerebellum with detailed neuron models.",
             "contributors": [
               {"name": "Egidio d’Angelo", "email": "egidiougo.dangelo@unipv.it"},
-              {"name": "Stefano Casali", "email": "stefano.casali01@universitadipavia.it"}
+              {"name": "Stefano Casali", "email": "stefano.casali@unipv.it"},
+			  {"name": "Claudia Casellato", "email": "claudia.casellato@unipv.it"},
+			  {"name": "Elisa Marenzi", "email": "elisa.marenzi@unipv.it"}
             ],
             "img": "https://github.com/antonelepfl/usecases/raw/dev/src/assets/images/cerebellum.png"
           },
@@ -846,7 +849,8 @@
                 "appid": 175,
                 "contenttype": "x-ipynb+json",
                 "extension": ".ipynb",
-                "file": "5f395bc1-7b31-4393-b64f-76d8e76b3851"
+                #"file": "5f395bc1-7b31-4393-b64f-76d8e76b3851"
+				"file": "85354cea-5f47-4852-8c8f-8cacf5d38333"
               }
             ],
             "species": "Rat",
@@ -855,7 +859,9 @@
             "description": "A volume of the cerebellum with detailed neuron models.",
             "contributors": [
               {"name": "Egidio d’Angelo", "email": "egidiougo.dangelo@unipv.it"},
-              {"name": "Stefano Casali", "email": "stefano.casali01@universitadipavia.it"}
+              {"name": "Stefano Casali", "email": "stefano.casali@unipv.it"},
+			  {"name": "Claudia Casellato", "email": "claudia.casellato@unipv.it"},
+			  {"name": "Elisa Marenzi", "email": "elisa.marenzi@unipv.it"}
             ],
             "img": "https://github.com/antonelepfl/usecases/raw/dev/src/assets/images/cerebellum.png"
           },
@@ -973,6 +979,29 @@
         },
         "next": "small_circuits",
         "models": [
+		  {
+            "title": "Cerebellum microcircuit",
+			"files": [
+              {
+                "entryname": "Cerebellum microcircuit",
+                "appid": 175,
+                "contenttype": "x-ipynb+json",
+                "extension": ".ipynb",
+				"file": "da012b41-4a6b-4b5d-9b71-869c1c68d731"
+              }
+            ],
+            "species": "Rat",
+            "brain_structure": "cerebellum",
+            "cell_soma_location": "cerebellar cortex and DCN",
+            "description": "Cerebellum microcircuit simulation with PyNEST",
+            "contributors": [
+              {"name": "Egidio d’Angelo", "email": "egidiougo.dangelo@unipv.it"},
+              {"name": "Stefano Casali", "email": "stefano.casali@unipv.it"},
+			  {"name": "Claudia Casellato", "email": "claudia.casellato@unipv.it"},
+			  {"name": "Elisa Marenzi", "email": "elisa.marenzi@unipv.it"}
+            ],
+            "img": "https://github.com/antonelepfl/usecases/raw/dev/src/assets/images/cerebellum.png"
+          },
           {
             "title": "Rat hippocampus CA1",
             "species": "Rat",
@@ -984,6 +1013,8 @@
             ],
             "img": "https://github.com/antonelepfl/usecases/raw/dev/src/assets/images/hippocampusConnections.png"
           }
+        ]
+          
         ]
       },
       {

--- a/src/assets/config_files/usecases.json
+++ b/src/assets/config_files/usecases.json
@@ -791,7 +791,6 @@
                 "appid": 175,
                 "contenttype": "x-ipynb+json",
                 "extension": ".ipynb",
-                #"file": "67555a8f-70f6-4b81-9f2b-c343deb0779c"
 				"file": "b0509c3f-3330-435d-87d2-d0940e98766c"
               }
             ],
@@ -849,7 +848,6 @@
                 "appid": 175,
                 "contenttype": "x-ipynb+json",
                 "extension": ".ipynb",
-                #"file": "5f395bc1-7b31-4393-b64f-76d8e76b3851"
 				"file": "85354cea-5f47-4852-8c8f-8cacf5d38333"
               }
             ],


### PR DESCRIPTION
update cerebellum scaffold usecases: cells placement, connectome and small circuit in silico simulation.