### PR TITLE
Update common_headers.ipynb

### DIFF
--- a/production_notebooks/common_header/common_headers.ipynb
+++ b/production_notebooks/common_header/common_headers.ipynb
@@ -18,9 +18,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# This cell specifies dynamic data and code to check if an updated version of this notebook is available. Do not make any changes to this cell.\n",
-    "# id = TEST_ID\n",
-    "# GITHUB_FILE_PATH"
+    "!curl https://raw.githubusercontent.com/antonelepfl/usecases/tree/dev/production_notebooks/common_header/master/nbversioncheck.py > nbversioncheck.py\n",
+    "notebook_id = NOTEBOOK_ID\n",
+    "notebook_url = NOTEBOOK_URL\n",
+    "from nbversioncheck import NBVersionCheck\n",
+    "check = NBVersionCheck(notebook_id, notebook_url, get_hbp_service_client(), get_collab_storage_path())\n",  
+    "check.check()"
    ]
   }
  ],


### PR DESCRIPTION
Updated header to download the python script, define the SHA hash of the current notebook, and the URL of the original notebook