### PR TITLE
enabled setup of Analysis with webSDA usecse, as this is logically be…

### DIFF
--- a/src/assets/config_files/usecases.json
+++ b/src/assets/config_files/usecases.json
@@ -1,6 +1,26 @@
-[
+f[
   {
     "molecular": [
+      {
+        "title": "Calculation of bimolecular association rates with webSDA",
+        "description": "Starting from a structure of the complex formed between adenylyl cyclase 5 and Gαolf obtained from a molecular dynamics simulation, set up all the files required to perform a Brownian dynamics simulation with SDA.",
+        "experience": ["all"],
+        "maturity": ["beta"],
+        "disabled": false,
+        "picture": {
+          "src": "https://raw.githubusercontent.com/antonelepfl/usecases/dev/src/assets/images/sda7_large.jpg"
+        },
+        "next": "ta_form",
+        "dataprotected": true,
+        "files": [
+          {
+           "entryname": "Calculation of bimolecular association rates with webSDA",
+           "contentype": "text/html",
+           "extension": ".html",
+           "file": "collab/50197/nav/561166"
+          }
+        ]
+      },
       {
         "title": "Analyse the results of a Brownian dynamics simulation for calculating protein-protein association rate constants",
         "description": "Analyse the results of an SDA Brownian dynamics simulation to calculate the rate constant of Gαolf associating to adenylyl cyclase 5, and estimate the error in this prediction via bootstrapping.",
@@ -327,19 +347,6 @@
             "initial": true
           }
         ]
-      },
-      {
-        "title": "Set up a Brownian dynamics simulation for calculating protein-protein association rate constants",
-        "description": "Starting from a structure of the complex formed between adenylyl cyclase 5 and Gαolf obtained from a molecular dynamics simulation, set up all the files required to perform a Brownian dynamics simulation with SDA.",
-        "experience": ["all"],
-        "maturity": ["beta"],
-        "disabled": true,
-        "picture": {
-          "src": "https://raw.githubusercontent.com/antonelepfl/usecases/dev/src/assets/images/sda7_large.jpg"
-        },
-        "next": "ta_form",
-        "dataprotected": true,
-        "files": []
       },
       {
         "title": "Tools to search and analyze molecules",

--- a/src/assets/config_files/usecases.json
+++ b/src/assets/config_files/usecases.json
@@ -1,4 +1,4 @@
-f[
+[
   {
     "molecular": [
       {

--- a/src/assets/config_files/usecases.json
+++ b/src/assets/config_files/usecases.json
@@ -2,7 +2,7 @@ f[
   {
     "molecular": [
       {
-        "title": "Calculation of bimolecular association rates with webSDA",
+        "title": "Calculate protein-protein bimolecular association rate constants with webSDA",
         "description": "Starting from a structure of the complex formed between adenylyl cyclase 5 and Gαolf obtained from a molecular dynamics simulation, set up all the files required to perform a Brownian dynamics simulation with SDA.",
         "experience": ["all"],
         "maturity": ["beta"],
@@ -12,7 +12,13 @@ f[
         },
         "next": "ta_form",
         "dataprotected": true,
-        "files": [
+         "contributors": [
+          {"name": "Stefan Richter", "email": "mcmsoft@h-its.org"},
+          {"name": "Daria Kokh", "email": "mcmsoft@h-its.org"},
+          {"name": "Rebecca Wade", "email": "mcmsoft@h-its.org"},
+	  {"name": "Neil Bruce", "email": "mcmsoft@h-its.org"}
+         ],
+ 	"files": [
           {
            "entryname": "Calculation of bimolecular association rates with webSDA",
            "contentype": "text/html",

--- a/src/assets/config_files/usecases.json
+++ b/src/assets/config_files/usecases.json
@@ -10,22 +10,14 @@
         "picture": {
           "src": "https://raw.githubusercontent.com/antonelepfl/usecases/dev/src/assets/images/sda7_large.jpg"
         },
-        "next": "ta_form",
         "dataprotected": true,
-         "contributors": [
+        "contributors": [
           {"name": "Stefan Richter", "email": "mcmsoft@h-its.org"},
           {"name": "Daria Kokh", "email": "mcmsoft@h-its.org"},
           {"name": "Rebecca Wade", "email": "mcmsoft@h-its.org"},
-	  {"name": "Neil Bruce", "email": "mcmsoft@h-its.org"}
-         ],
- 	"files": [
-          {
-           "entryname": "Calculation of bimolecular association rates with webSDA",
-           "contentype": "text/html",
-           "extension": ".html",
-           "file": "collab/50197/nav/561166"
-          }
-        ]
+          {"name": "Neil Bruce", "email": "mcmsoft@h-its.org"}
+        ],
+        "external_link": "https://websda.h-its.org"
       },
       {
         "title": "Analyse the results of a Brownian dynamics simulation for calculating protein-protein association rate constants",


### PR DESCRIPTION
…fore the next use case, it is put in front of it

This was discussed with Alexander Dietz. This is a general description on the use case currently still disabled in the molecular level. I will add this use case also today. The guide book also stands by its own. It goes into details how to create analysis like in the live paper https://humanbrainproject.github.io/hbp-bsp-live-papers/2019/bruce_et_al_2019/bruce_et_al_2019.html

Alexander also asked somebody who would be able to evaluate and test this, for this case we would suggest: (... mail address will be send by mail)